### PR TITLE
Basic Gear 360 camera (2017) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Supported Cameras
 -
 
 - [Ricoh Theta S](https://developers.theta360.com/en/)
+- [Samsung Gear 360 (2017)](https://www.samsung.com/global/galaxy/gear-360/)
 - Untested OSC cameras
 	- [BublCam](http://www.bublcam.com/)
 	- [Giroptic](http://us.360.tv/en/)
@@ -111,6 +112,8 @@ References
 
 - [Alternate OSC Python library](https://github.com/florianl/pyOSCapi)
 
+- [Samsung Gear 360 (2016) OSC Python library](https://github.com/baardove/osc)
+
 Thanks
 ------
 Many thanks to Craig Oda, the author and maintainer of [Theta S API Tests](https://github.com/codetricity/theta-s-api-tests) repo.
@@ -124,7 +127,7 @@ The original author of this library is:
 Testing
 -
 
-This library was tested with a Ricoh Theta S using Python 2.7 on OSX Yosemite.
+This library was tested with a Ricoh Theta S using Python 2.7 on OSX Yosemite, and a Samsung Gear 360 (2017) on macOS High Sierra.
 
 License
 -

--- a/python/osc/gear360_2017.py
+++ b/python/osc/gear360_2017.py
@@ -1,0 +1,59 @@
+"""
+Extensions to the Open Spherical Camera API specific to the Gear 360 camera (2017).
+
+Usage:
+At the top of your Python script, use
+
+  from osc.gear360_2017 import Gear360_2017
+
+After you import the library, you can use the commands like this:
+
+  gear360 = Gear360_2017()
+  gear360.state()
+  gear360.info()
+
+  # Capture image
+  response = gear360.takePicture()
+
+  # Wait for the stitching to finish
+  gear360.waitForProcessing(response['id'])
+
+  # Copy image to computer
+  gear360.getLatestImage()
+
+  gear360.closeSession()
+"""
+
+import osc
+
+class Gear360_2017(osc.OpenSphericalCamera):
+
+    # Instance variables / methods
+    def __init__(self, ip_base="192.168.43.1", httpPort=80):
+        self.sid = None
+        self.fingerprint = None
+        self._api = None
+
+        self._ip = ip_base
+        self._httpPort = httpPort
+        self._httpUpdatesPort = httpPort
+
+        # Try to start a session
+        self.startSession()
+
+        # Use 'info' command to retrieve more information
+        self._info = self.info()
+        if self._info:
+            self._api = self._info['api']
+            self._httpPort = self._info['endpoints']['httpPort']
+            self._httpUpdatesPort = self._info['endpoints']['httpUpdatePort']
+
+    def latestFileUri(self):
+        x = self.listImages(1)
+        if 'results' in x:
+            if 'entries' in x['results']:
+                if len(x['results']['entries']) == 1:
+                    if 'uri' in x['results']['entries'][0]:
+                        return x['results']['entries'][0]['uri']
+        return None
+


### PR DESCRIPTION
Hello, this adds basic Samsung Gear 360 camera (2017) support.

The `info` response calls the `httpUpdatesPort` instead `httpUpdatePort` (no "s").

The `state` response doesn't include the latest file URI.

(Also, the battery level response is always 1.0, and so is useless.)